### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-Automata TDX Attestation SDK is the most-feature complete SDK for Intel TDX development, it consists three parts:
+Automata TDX Attestation SDK is the most-feature complete SDK for Intel TDX development, it consists of three parts:
 
 * TDX package: it helps developers to generate the Intel TDX Quote in different cloud service providers (CSP).
 * Risc0 and Succinct CLIs to interact with the corresponding zkVM servers to generate the proofs, and constructs the [Automata DCAP Attestation](https://github.com/automata-network/automata-dcap-attestation) contracts calls to perform the on-chain verification.

--- a/tdx/README.md
+++ b/tdx/README.md
@@ -45,7 +45,7 @@ The example should successfully generate and verify an attestation report on any
 
 ## Rust API Usage
 
-### Initialise Tdx object
+### Initialize Tdx object
 
 In order to run the next few steps, first initialise a Tdx object:
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "consists three parts" to "consists of three parts".
Corrected "Initialise" to "Initialize".

Please review the changes and let me know if any additional changes are needed.