### PR TITLE
Title: Fix spelling of "initialise" to "initialize" for consistency

### DIFF
--- a/tdx/README.md
+++ b/tdx/README.md
@@ -47,7 +47,7 @@ The example should successfully generate and verify an attestation report on any
 
 ### Initialize Tdx object
 
-In order to run the next few steps, first initialise a Tdx object:
+In order to run the next few steps, first initialize a Tdx object:
 
 ```rust
 use tdx::Tdx;


### PR DESCRIPTION
Commit Description: Fixed the spelling of "initialise" (British English) to "initialize" (American English).

Why it matters: It's important to maintain consistency with American English, which is the standard in programming and software development. This aligns the documentation with common practices in the Rust ecosystem and other modern technologies.