### PR TITLE
fix: update 404 links

### DIFF
--- a/zk/sp1/README.md
+++ b/zk/sp1/README.md
@@ -5,7 +5,7 @@ Leveraging from the [SP1](https://github.com/succinctlabs/sp1) project template,
 ## Requirements
 
 - [Rust](https://rustup.rs/)
-- [SP1](https://docs.succinct.xyz/getting-started/install.html)
+- [SP1](https://docs.succinct.xyz/docs/sp1/getting-started/install)
 - [Docker](https://docs.docker.com/get-started/get-docker/)
 
 ## Running the Project
@@ -55,7 +55,7 @@ cargo prove vkey --elf elf/dcap-sp1-guest-program-elf
 
 ## Using the Prover Network
 
-We highly recommend using the Succinct prover network for any non-trivial programs or benchmarking purposes. For more information, see the [setup guide](https://docs.succinct.xyz/docs/generating-proofs/prover-network/usage).
+We highly recommend using the Succinct prover network for any non-trivial programs or benchmarking purposes. For more information, see the [setup guide](https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network/usage).
 
 To get started, copy the example environment file:
 


### PR DESCRIPTION
Hi! I updated the SP1 documentation link in the `zk/sp1/README.md` file because the old link led to a non-existent page (404).