### PR TITLE
Update alloy dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4.3"
 rand = "0.8.5"
 serde = "1.0.217"
 ureq = { version = "2.12.1", features = ["json"] }
-alloy = "0.12.5"
+alloy = "1.0.20"
 anyhow = "1.0.97"
 chrono = "0.4.40"
 tokio = { version = "1.44.1", features = ["rt-multi-thread"] }

--- a/tdx/src/pccs/enclave_id.rs
+++ b/tdx/src/pccs/enclave_id.rs
@@ -23,7 +23,7 @@ sol! {
 
 pub async fn get_enclave_identity(version: u32) -> Result<Vec<u8>> {
     let rpc_url = DEFAULT_RPC_URL.parse().expect("Failed to parse RPC URL");
-    let provider = ProviderBuilder::new().on_http(rpc_url);
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     let enclave_id_dao_address_slice =
         hex::decode(ENCLAVE_ID_DAO_ADDRESS).expect("Invalid address hex");
@@ -41,8 +41,8 @@ pub async fn get_enclave_identity(version: u32) -> Result<Vec<u8>> {
 
     let call_return = call_builder.call().await?;
 
-    let identity_str = call_return.enclaveIdObj.identityStr;
-    let signature_bytes = call_return.enclaveIdObj.signature;
+    let identity_str = call_return.identityStr;
+    let signature_bytes = call_return.signature;
 
     if identity_str.len() == 0 || signature_bytes.len() == 0 {
         return Err(anyhow::Error::msg(format!(

--- a/tdx/src/pccs/fmspc_tcb.rs
+++ b/tdx/src/pccs/fmspc_tcb.rs
@@ -23,7 +23,7 @@ sol! {
 
 pub async fn get_tcb_info(tcb_type: u8, fmspc: &str, version: u32) -> Result<Vec<u8>> {
     let rpc_url = DEFAULT_RPC_URL.parse().expect("Failed to parse RPC URL");
-    let provider = ProviderBuilder::new().on_http(rpc_url);
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     let fmspc_tcb_dao_address_slice =
         hex::decode(FMSPC_TCB_DAO_ADDRESS).expect("Invalid address hex");
@@ -37,8 +37,8 @@ pub async fn get_tcb_info(tcb_type: u8, fmspc: &str, version: u32) -> Result<Vec
     );
 
     let call_return = call_builder.call().await?;
-    let tcb_info_str = call_return.tcbObj.tcbInfoStr;
-    let signature_bytes = call_return.tcbObj.signature;
+    let tcb_info_str = call_return.tcbInfoStr;
+    let signature_bytes = call_return.signature;
 
     if tcb_info_str.len() == 0 || signature_bytes.len() == 0 {
         return Err(anyhow::Error::msg(format!(

--- a/tdx/src/pccs/pcs.rs
+++ b/tdx/src/pccs/pcs.rs
@@ -20,7 +20,7 @@ sol! {
 
 pub async fn get_certificate_by_id(ca_id: IPCSDao::CA) -> Result<(Vec<u8>, Vec<u8>)> {
     let rpc_url = DEFAULT_RPC_URL.parse().expect("Failed to parse RPC URL");
-    let provider = ProviderBuilder::new().on_http(rpc_url);
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     let pcs_dao_address_slice = hex::decode(PCS_DAO_ADDRESS).expect("invalid address hex");
     let pcs_dao_contract = IPCSDao::new(Address::from_slice(&pcs_dao_address_slice), &provider);


### PR DESCRIPTION
Update alloy dependencies as it is incompatible with reth alloy dependencies when trying to import into the op-rbuilder workspace