### PR TITLE
Subject: chore(host): remove obsolete TODO about retrieving receipt journal

### DIFF
--- a/zk/risc0/host/src/main.rs
+++ b/zk/risc0/host/src/main.rs
@@ -90,8 +90,6 @@ fn main() {
         )
     }
 
-    // TODO: Implement code for retrieving receipt journal here.
-
     // Optional: Verify receipt to confirm that recipients will also be able to
     // verify your receipt
     receipt.verify(DCAP_GUEST_ID).unwrap();


### PR DESCRIPTION
The receipt journal is already retrieved and parsed below (verification and receipt.journal.bytes), so the TODO was stale and misleading.