### PR TITLE
fix: correct misleading comment about device type in get_attestation_report_raw

### DIFF
--- a/tdx/src/device.rs
+++ b/tdx/src/device.rs
@@ -77,7 +77,7 @@ impl Device {
             let quote = base64_url::decode(&quote_response.quote)?;
             return Ok((quote, response.var_data));
         }
-        // Otherwise we can just return the quote from the TPM as it is.
+        // Otherwise we can just return the quote from the device as it is.
         Ok((response.report, response.var_data))
     }
 }


### PR DESCRIPTION


The comment previously stated "Otherwise we can just return the quote from the TPM as it is"
but this code path actually executes for all device types EXCEPT TPM (ConfigFS and Legacy).