### PR TITLE
fix(zk/risc0): correct journal comment to sgx_intel_root_ca_crl_hash

### DIFF
--- a/zk/risc0/methods/guest/src/main.rs
+++ b/zk/risc0/methods/guest/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
     // qeidentity_content_hash
     // sgx_intel_root_ca_cert_hash
     // sgx_tcb_signing_cert_hash
-    // sgx_tcb_intel_root_ca_crl_hash
+    // sgx_intel_root_ca_crl_hash
     // sgx_pck_platform_crl_hash or sgx_pck_processor_crl_hash
     let journal_len = serial_output.len() + 226;
     let mut journal_output: Vec<u8> = Vec::with_capacity(journal_len);


### PR DESCRIPTION
Update the journal format comment to use sgx_intel_root_ca_crl_hash.
The code emits the Intel Root CA CRL hash (not a “TCB” CRL), and the host parses it as the root CRL. The previous label sgx_tcb_intel_root_ca_crl_hash was misleading and could confuse readers about which CRL is hashed.
This change aligns the comment with actual behavior and DCAP terminology, improving clarity and preventing misinterpretation.