### PR TITLE
chore: small cleanups across error handling and device API

### DIFF
--- a/tdx/src/device.rs
+++ b/tdx/src/device.rs
@@ -27,13 +27,9 @@ struct QuoteResponse {
 }
 
 impl Device {
-    pub fn default() -> Result<Self> {
-        let options = DeviceOptions { report_data: None };
-        let provider = get_coco_provider()?;
-        if provider.device_type == CocoDeviceType::Mock {
-            return Err(TdxError::ConfigOptions("Mock device is not supported".to_string()));
-        }
-        Ok(Device { options, provider })
+    /// Create a Device with default options (random `report_data`).
+    pub fn with_default_options() -> Result<Self> {
+        Self::new(DeviceOptions { report_data: None })
     }
 
     pub fn new(options: DeviceOptions) -> Result<Self> {

--- a/tdx/src/error.rs
+++ b/tdx/src/error.rs
@@ -30,25 +30,25 @@ pub enum TdxError {
 
 impl From<CocoError> for TdxError {
     fn from(err: CocoError) -> Self {
-        TdxError::Firmware(format!("{:?}", err))
+        TdxError::Firmware(err.to_string())
     }
 }
 
 impl From<base64_url::base64::DecodeError> for TdxError {
     fn from(err: base64_url::base64::DecodeError) -> Self {
-        TdxError::IO(format!("{:?}", err))
+        TdxError::IO(err.to_string())
     }
 }
 
 impl From<std::io::Error> for TdxError {
     fn from(err: std::io::Error) -> Self {
-        TdxError::IO(format!("{:?}", err))
+        TdxError::IO(err.to_string())
     }
 }
 
 impl From<ureq::Error> for TdxError {
     fn from(err: ureq::Error) -> Self {
-        TdxError::Http(format!("{:?}", err))
+        TdxError::Http(err.to_string())
     }
 }
 
@@ -60,6 +60,6 @@ impl From<anyhow::Error> for TdxError {
 
 impl From<std::str::Utf8Error> for TdxError {
     fn from(err: std::str::Utf8Error) -> Self {
-        TdxError::IO(format!("{:?}", err))
+        TdxError::IO(err.to_string())
     }
 }

--- a/tdx/src/lib.rs
+++ b/tdx/src/lib.rs
@@ -30,7 +30,7 @@ impl Tdx {
     /// Var data is only available if the device resides on an Azure Confidential VM.
     /// Var data provided by Azure can be used to verify the contents of the attestation report's report_data
     pub fn get_attestation_report_raw(&self) -> Result<(Vec<u8>, Option<Vec<u8>>)> {
-        let device = device::Device::default()?;
+        let device = device::Device::with_default_options()?;
         device.get_attestation_report_raw()
     }
 
@@ -77,7 +77,7 @@ impl Tdx {
         .await
         .map_err(|e| match e {
             CollateralError::Missing(report) => {
-                TdxError::Http(format!("Missing collaterals: {:?}", report))
+                TdxError::Http(format!("Missing collaterals: {report:?}"))
             }
             CollateralError::Validation(msg) => {
                 TdxError::Http(format!("Validation error: {}", msg))

--- a/tdx/src/utils.rs
+++ b/tdx/src/utils.rs
@@ -10,12 +10,11 @@ pub enum PckCA {
     Platform,
     Processor,
 }
-/// Generates 64 bytes of random data
-/// Always guaranteed to return something (ie, unwrap() can be safely called)
-pub fn generate_random_data() -> Option<[u8; 64]> {
+/// Generates 64 bytes of random data.
+pub fn generate_random_data() -> [u8; 64] {
     let mut data = [0u8; 64];
     rand::thread_rng().fill_bytes(&mut data);
-    Some(data)
+    data
 }
 
 pub fn der_to_pem_bytes(der_bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
  - utils: `generate_random_data()` returns `[u8; 64]` directly instead of `Option<[u8; 64]>` (the previous Option could never be None).
  - error: `From<E>` impls now use `Display ({})` instead of `Debug ({:?})` so error messages render as human-readable strings rather than Rust struct dumps.
  - device: dedupe `Device::default()` / `Device::new(opts)` by routing the former through the latter, and rename it to `Device::with_default_options()` to avoid being mistaken for the Default trait (which it is not — it returns Result).

No behavior change in the SDK's public attestation flow.