### PR TITLE
fix: update dcap dependencies to v1.1.2

### DIFF
--- a/tdx/Cargo.toml
+++ b/tdx/Cargo.toml
@@ -35,7 +35,7 @@ pem.workspace = true
 thiserror.workspace = true
 
 coco-provider = { git = "https://github.com/automata-network/coco-provider-sdk", optional = true, default-features = false }
-dcap-rs = { git = "https://github.com/automata-network/automata-dcap-attestation", rev="b996b1b" }
+dcap-rs = { git = "https://github.com/automata-network/automata-dcap-attestation", rev="v1.1.2" }
 # Automata DCAP libraries for on-chain PCCS, v1.1
-pccs-reader-rs = { git = "https://github.com/automata-network/automata-dcap-attestation", rev = "b996b1b" }
-automata-dcap-network-registry = { git = "https://github.com/automata-network/automata-dcap-attestation", rev = "b996b1b" }
+pccs-reader-rs = { git = "https://github.com/automata-network/automata-dcap-attestation", rev = "v1.1.2" }
+automata-dcap-network-registry = { git = "https://github.com/automata-network/automata-dcap-attestation", rev = "v1.1.2" }

--- a/tdx/src/device.rs
+++ b/tdx/src/device.rs
@@ -50,7 +50,7 @@ impl Device {
                 }
                 None
             }
-            _ => self.options.report_data.or_else(generate_random_data),
+            _ => self.options.report_data.or_else(|| Some(generate_random_data())),
         };
         let req = ReportRequest {
             report_data,


### PR DESCRIPTION
Use automata-dcap-attestation v1.1.2 so the Rust PCCS reader can resolve the Hoodi V2 DAO registry addresses. Also wrap generated report data in Some(...) to satisfy the Device report_data type.